### PR TITLE
Replacing packaging requirement with Sceptre requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Categories: Added, Removed, Changed, Fixed, Nonfunctional, Deprecated
 <!--- All unreleased items go here  -->
 
 <!--- Example CHANGELOG entry
+## 0.1.1 (2022.03.02)
+- Replaced pinned packaging requirement with Sceptre >= 2.7
 
 ## 0.1.0 (2019.07.02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ Categories: Added, Removed, Changed, Fixed, Nonfunctional, Deprecated
 <!--- All unreleased items go here  -->
 
 <!--- Example CHANGELOG entry
-## 0.1.1 (2022.03.02)
-- Replaced pinned packaging requirement with Sceptre >= 2.7
 
 ## 0.1.0 (2019.07.02)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 bumpversion==0.5.3
 coverage==4.4.2
 pre-commit>=2.12.0,<2.13
-packaging==16.8
 pytest-runner>=3.0.0,<3.1.0
 pytest>=3.2.0,<3.3.0
 readme-renderer>=24.0

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 # More information on setting values:
 # https://github.com/Sceptre/project/wiki/sceptre-template-handler-template
@@ -25,7 +25,7 @@ with open("README.md") as readme_file:
     README = readme_file.read()
 
 install_requirements = [
-    "packaging==16.8"
+    "sceptre>=2.7"
 ]
 
 test_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-__version__ = "0.1.1"
+__version__ = "0.1.0"
 
 # More information on setting values:
 # https://github.com/Sceptre/project/wiki/sceptre-template-handler-template


### PR DESCRIPTION
We need to remove the pinned version of packaging in order to support updating it in Sceptre. In any case, we shouldn't have ever pinned it. There's nothing in this package that actually makes use of `packaging` as a requirement.