### PR TITLE
Generate github test matrix from tox

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,6 +44,7 @@ jobs:
       - id: generate-envlist
         run: poetry run tox --gh-matrix
   unit-tests:
+    needs: get-tox-envlist
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,12 +29,26 @@ jobs:
         run: poetry install --no-interaction --all-extras
       - name: build package
         run: poetry build
+  # use https://github.com/medmunds/tox-gh-matrix to export tox envlist to GH actions
+  get-tox-envlist:
+    runs-on: ubuntu-latest
+    outputs:
+      envlist: ${{ steps.generate-envlist.outputs.envlist }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Install Poetry
+        uses: snok/install-poetry@v1
+      - name: Install dependencies
+        run: poetry install --no-interaction --all-extras
+      - id: generate-envlist
+        run: poetry run tox --gh-matrix
   unit-tests:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        tox: ${{ fromJSON(needs.get-tox-envlist.outputs.envlist) }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -42,12 +56,12 @@ jobs:
         id: setup-python
         uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python }}
+          python-version: ${{ matrix.tox.python.spec }}
       - name: Install Poetry
         uses: snok/install-poetry@v1
       - name: Install dependencies
         run: poetry install --no-interaction --all-extras
       - name: run python tests
-        run: poetry run tox -e py
+        run: poetry run tox -e ${{ matrix.tox.name }}
       - name: run python test report
         run: poetry run tox -e report

--- a/poetry.lock
+++ b/poetry.lock
@@ -21,17 +21,17 @@ tests-no-zope = ["attrs[tests-mypy]", "cloudpickle", "hypothesis", "pympler", "p
 
 [[package]]
 name = "boto3"
-version = "1.34.21"
+version = "1.34.22"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">= 3.8"
 files = [
-    {file = "boto3-1.34.21-py3-none-any.whl", hash = "sha256:88e3baeb53ae421aabd44bb49ebdd7122b74b53b0f437b0f3e17141f6744574a"},
-    {file = "boto3-1.34.21.tar.gz", hash = "sha256:206e61ba1f8c830e5df0355606d178ad5bc970df12c4c318b021c71da410eb0c"},
+    {file = "boto3-1.34.22-py3-none-any.whl", hash = "sha256:5909cd1393143576265c692e908a9ae495492c04a0ffd4bae8578adc2e44729e"},
+    {file = "boto3-1.34.22.tar.gz", hash = "sha256:a98c0b86f6044ff8314cc2361e1ef574d674318313ab5606ccb4a6651c7a3f8c"},
 ]
 
 [package.dependencies]
-botocore = ">=1.34.21,<1.35.0"
+botocore = ">=1.34.22,<1.35.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.10.0,<0.11.0"
 
@@ -40,13 +40,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.34.21"
+version = "1.34.22"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">= 3.8"
 files = [
-    {file = "botocore-1.34.21-py3-none-any.whl", hash = "sha256:43274fd3f8e02573790ee76313607c60e3c15a7a0d89d24dfe4042f882f1f8c9"},
-    {file = "botocore-1.34.21.tar.gz", hash = "sha256:21983bb0473a19130192c50ec6974d55f0c4aa48a7094bcf40f7882c8b69b8f1"},
+    {file = "botocore-1.34.22-py3-none-any.whl", hash = "sha256:e5f7775975b9213507fbcf846a96b7a2aec2a44fc12a44585197b014a4ab0889"},
+    {file = "botocore-1.34.22.tar.gz", hash = "sha256:c47ba4286c576150d1b6ca6df69a87b5deff3d23bd84da8bcf8431ebac3c40ba"},
 ]
 
 [package.dependencies]
@@ -59,17 +59,6 @@ urllib3 = [
 
 [package.extras]
 crt = ["awscrt (==0.19.19)"]
-
-[[package]]
-name = "cachetools"
-version = "5.3.2"
-description = "Extensible memoizing collections and decorators"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "cachetools-5.3.2-py3-none-any.whl", hash = "sha256:861f35a13a451f94e301ce2bec7cac63e881232ccce7ed67fab9b5df4d3beaa1"},
-    {file = "cachetools-5.3.2.tar.gz", hash = "sha256:086ee420196f7b2ab9ca2db2520aca326318b68fe5ba8bc4d49cca91add450f2"},
-]
 
 [[package]]
 name = "certifi"
@@ -108,17 +97,6 @@ files = [
 Click = "*"
 PyYAML = ">=4.1"
 six = "*"
-
-[[package]]
-name = "chardet"
-version = "5.2.0"
-description = "Universal encoding detector for Python 3"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970"},
-    {file = "chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7"},
-]
 
 [[package]]
 name = "charset-normalizer"
@@ -235,13 +213,13 @@ colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "colorama"
-version = "0.4.6"
+version = "0.4.3"
 description = "Cross-platform colored terminal text."
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 files = [
-    {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
-    {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
+    {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
+    {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
 ]
 
 [[package]]
@@ -327,6 +305,20 @@ ordered-set = ">=4.1.0,<4.2.0"
 
 [package.extras]
 cli = ["clevercsv (==0.7.1)", "click (==8.0.3)", "pyyaml (==5.4.1)", "toml (==0.10.2)"]
+
+[[package]]
+name = "deprecation"
+version = "2.1.0"
+description = "A library to handle automated deprecations"
+optional = false
+python-versions = "*"
+files = [
+    {file = "deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a"},
+    {file = "deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff"},
+]
+
+[package.dependencies]
+packaging = "*"
 
 [[package]]
 name = "distlib"
@@ -632,6 +624,17 @@ pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
 
 [[package]]
+name = "py"
+version = "1.11.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+files = [
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+]
+
+[[package]]
 name = "pyparsing"
 version = "3.1.1"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
@@ -644,25 +647,6 @@ files = [
 
 [package.extras]
 diagrams = ["jinja2", "railroad-diagrams"]
-
-[[package]]
-name = "pyproject-api"
-version = "1.5.0"
-description = "API to interact with the python pyproject.toml based projects"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "pyproject_api-1.5.0-py3-none-any.whl", hash = "sha256:4c111277dfb96bcd562c6245428f27250b794bfe3e210b8714c4f893952f2c17"},
-    {file = "pyproject_api-1.5.0.tar.gz", hash = "sha256:0962df21f3e633b8ddb9567c011e6c1b3dcdfc31b7860c0ede7e24c5a1200fbe"},
-]
-
-[package.dependencies]
-packaging = ">=21.3"
-tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
-
-[package.extras]
-docs = ["furo (>=2022.9.29)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.5)"]
-testing = ["covdefaults (>=2.2.2)", "importlib-metadata (>=5.1)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)", "virtualenv (>=20.17)", "wheel (>=0.38.4)"]
 
 [[package]]
 name = "pyrsistent"
@@ -858,47 +842,47 @@ crt = ["botocore[crt] (>=1.33.2,<2.0a.0)"]
 
 [[package]]
 name = "sceptre"
-version = "3.3.1"
-description = "Cloud Provisioning Tool"
+version = "4.4.2"
+description = "An AWS Cloud Provisioning Tool"
 optional = false
-python-versions = "*"
+python-versions = ">=3.8,<4.0"
 files = [
-    {file = "sceptre-3.3.1-py2.py3-none-any.whl", hash = "sha256:f2fe0f13376099b5c82fe70d27f39d7b629999044c5d8d950d1bde8de97edffb"},
-    {file = "sceptre-3.3.1.tar.gz", hash = "sha256:e3d7288f58bd847345123452c8555be4c64aab59f5501d2c5f5e7b3e752a0c44"},
+    {file = "sceptre-4.4.2-py3-none-any.whl", hash = "sha256:b5072ca390640f9966bd0277fa3ef26285f741557d8814ef51a81fa715925c6f"},
+    {file = "sceptre-4.4.2.tar.gz", hash = "sha256:5bb5683233346dc9bb7584d817851403f7b1c483d4d3ace805c76ebd09b9a49a"},
 ]
 
 [package.dependencies]
-boto3 = ">=1.3,<2.0"
-cfn-flip = ">=1.2.3,<2.0"
+boto3 = ">=1.20.27,<2.0.0"
+cfn-flip = ">=1.2.3,<2.0.0"
 click = ">=7.0,<9.0"
-colorama = ">=0.3.9"
-deepdiff = ">=5.5.0,<6.0"
-Jinja2 = ">=3.0,<4"
+colorama = ">=0.2.5,<0.4.4"
+deepdiff = ">=5.5,<6.0"
+deprecation = ">=2.0,<3.0"
+jinja2 = ">=3.0,<4.0"
 jsonschema = ">=3.2,<3.3"
 networkx = ">=2.6,<2.7"
 packaging = ">=16.8,<22.0"
-PyYaml = ">6.0,<7.0"
-sceptre-cmd-resolver = ">=1.1.3,<2"
-sceptre-file-resolver = ">=1.0.4,<2"
-six = ">=1.11.0,<2.0.0"
-urllib3 = "<2.0"
+pyyaml = ">=6.0,<7.0"
+sceptre-cmd-resolver = ">=2.0,<3.0"
+sceptre-file-resolver = ">=1.0,<2.0"
 
 [package.extras]
+docs = ["docutils (<0.17)", "sphinx (>=1.6.5,<=5.1.1)", "sphinx-autodoc-typehints (==1.19.2)", "sphinx-click (>=2.0.1,<4.0.0)", "sphinx-rtd-theme (==0.5.2)"]
 troposphere = ["troposphere (>=4,<5)"]
 
 [[package]]
 name = "sceptre-cmd-resolver"
-version = "1.2.1"
+version = "2.0.0"
 description = "Sceptre resolver to execute generic shell commands"
 optional = false
 python-versions = "*"
 files = [
-    {file = "sceptre-cmd-resolver-1.2.1.tar.gz", hash = "sha256:ff83298ae86a51df150de28cd17c3754c64aad2bc7813c3095cc5cfc7fad89f1"},
-    {file = "sceptre_cmd_resolver-1.2.1-py2.py3-none-any.whl", hash = "sha256:4cc7409ee43923bc97dc60b6d3bec2e129876e1ab9ca0ba656d4f8c40b2ac87b"},
+    {file = "sceptre-cmd-resolver-2.0.0.tar.gz", hash = "sha256:155c47e2f4f55c7b6eb64bfe8760174701442ecaddba1a6f5cb7715a1c95be99"},
+    {file = "sceptre_cmd_resolver-2.0.0-py2.py3-none-any.whl", hash = "sha256:eea8ce4cfcd9199f726b4280e7e35923c9d4ea5d75cbe4a8ee78c0d6d2996d09"},
 ]
 
 [package.dependencies]
-sceptre = ">=2.7"
+sceptre = ">=4.0.1"
 
 [package.extras]
 test = ["pytest (>=3.2)"]
@@ -961,30 +945,45 @@ files = [
 
 [[package]]
 name = "tox"
-version = "4.0.0"
+version = "3.28.0"
 description = "tox is a generic virtualenv management and test command line tool"
 optional = false
-python-versions = ">=3.7"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 files = [
-    {file = "tox-4.0.0-py3-none-any.whl", hash = "sha256:e6adcebddfec5e456e5d2884f82b9468e38c4ec6439ec97f7f1fb85d5b1bf846"},
-    {file = "tox-4.0.0.tar.gz", hash = "sha256:17643b0e29c41f784c9c266a13302dc0604884b9ceff6686fbb31bada4a7aa3a"},
+    {file = "tox-3.28.0-py2.py3-none-any.whl", hash = "sha256:57b5ab7e8bb3074edc3c0c0b4b192a4f3799d3723b2c5b76f1fa9f2d40316eea"},
+    {file = "tox-3.28.0.tar.gz", hash = "sha256:d0d28f3fe6d6d7195c27f8b054c3e99d5451952b54abdae673b71609a581f640"},
 ]
 
 [package.dependencies]
-cachetools = ">=5.2"
-chardet = ">=5.1"
-colorama = ">=0.4.6"
-filelock = ">=3.8.2"
-packaging = ">=21.3"
-platformdirs = ">=2.5.4"
-pluggy = ">=1"
-pyproject-api = ">=1.2.1"
-tomli = {version = ">=2.0.1", markers = "python_version < \"3.11\""}
-virtualenv = ">=20.17.1"
+colorama = {version = ">=0.4.1", markers = "platform_system == \"Windows\""}
+filelock = ">=3.0.0"
+packaging = ">=14"
+pluggy = ">=0.12.0"
+py = ">=1.4.17"
+six = ">=1.14.0"
+tomli = {version = ">=2.0.1", markers = "python_version >= \"3.7\" and python_version < \"3.11\""}
+virtualenv = ">=16.0.0,<20.0.0 || >20.0.0,<20.0.1 || >20.0.1,<20.0.2 || >20.0.2,<20.0.3 || >20.0.3,<20.0.4 || >20.0.4,<20.0.5 || >20.0.5,<20.0.6 || >20.0.6,<20.0.7 || >20.0.7"
 
 [package.extras]
-docs = ["furo (>=2022.9.29)", "sphinx (>=5.3)", "sphinx-argparse-cli (>=1.10)", "sphinx-autodoc-typehints (>=1.19.5)", "sphinx-copybutton (>=0.5.1)", "sphinx-inline-tabs (>=2022.1.2b11)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=22.8)"]
-testing = ["build[virtualenv] (>=0.9)", "covdefaults (>=2.2.2)", "devpi-process (>=0.3)", "diff-cover (>=7.2)", "distlib (>=0.3.6)", "flaky (>=3.7)", "hatch-vcs (>=0.2)", "hatchling (>=1.11.1)", "psutil (>=5.9.4)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)", "pytest-xdist (>=3.1)", "re-assert (>=1.1)", "time-machine (>=2.8.2)"]
+docs = ["pygments-github-lexers (>=0.0.5)", "sphinx (>=2.0.0)", "sphinxcontrib-autoprogram (>=0.1.5)", "towncrier (>=18.5.0)"]
+testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pathlib2 (>=2.3.3)", "psutil (>=5.6.1)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)"]
+
+[[package]]
+name = "tox-gh-matrix"
+version = "0.2.0"
+description = "Generate a GitHub workflow build matrix from the tox.ini envlist"
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "tox-gh-matrix-0.2.0.tar.gz", hash = "sha256:44ca327a4f74ec4085882571d5c46ec2dcd9ff76d38905416e58d1c1b8ffa1f1"},
+    {file = "tox_gh_matrix-0.2.0-py3-none-any.whl", hash = "sha256:122115d21bdc1fca1ae95eb729d19051d1886a429808b0da844bb26540761f32"},
+]
+
+[package.dependencies]
+tox = ">=3.15.2,<4"
+
+[package.extras]
+testing = ["pytest (>=6.2.0)", "pytest-cov (>=3.0.0)", "pytest-mock (>=3.6.0)", "pytest-xdist (>=2.3.0)"]
 
 [[package]]
 name = "urllib3"
@@ -1001,6 +1000,23 @@ files = [
 brotli = ["brotli (==1.0.9)", "brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
 secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)", "urllib3-secure-extra"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[[package]]
+name = "urllib3"
+version = "2.0.7"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "urllib3-2.0.7-py3-none-any.whl", hash = "sha256:fdb6d215c776278489906c2f8916e6e7d4f5a9b602ccbcfdf7f016fc8da0596e"},
+    {file = "urllib3-2.0.7.tar.gz", hash = "sha256:c97dfde1f7bd43a71c8d2a58e369e9b2bf692d1334ea9f9cae55add7d0dd0f84"},
+]
+
+[package.extras]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)"]
+secure = ["certifi", "cryptography (>=1.9)", "idna (>=2.0.0)", "pyopenssl (>=17.1.0)", "urllib3-secure-extra"]
+socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
+zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "virtualenv"
@@ -1024,5 +1040,5 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8,<3.12"
-content-hash = "01c684f426416826f185beaf9c99f35e1e8451d0fa7b7f602e5b130a797ff7d1"
+python-versions = "^3.8"
+content-hash = "0b9e351a16aba0c503e01b0112408637ac40b746005b2bd182506c0fd537e38f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,14 +24,15 @@ classifiers = [
 "custom" = "template_handler.custom:Custom"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.12"
+python = "^3.8"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.2.1"
-tox = "^4.0.0"
-pytest = "^7.2.2"
+tox = "^3.23.0"
+pytest = "^7.4.3"
 pytest-cov = "^4.0.0"
-sceptre = ">3.2"
+sceptre = "^4.0"
+tox-gh-matrix = "^0.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
We only want one static list of environments to run unit tests and that list should come from tox.ini

This sets up tox-gh-matrix[1] to dynamically generate the list of test environments for github actions to run. It will allow us to consolidate the list to just one for easier maintenance going forward.

[1] https://github.com/medmunds/tox-gh-matrix
